### PR TITLE
修复一个可能的安全漏洞

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -127,8 +127,10 @@ export function deleteBranch(branch) {
  */
 export function commit(message) {
     return new Promise((resolve, reject) => {
-        exec(`git commit -m "${message}"`, (err, stdout, stderr) => {
+        const env = { ...process.env, GIT_COMMIT_MESSAGE: message };
+        exec(`git commit -F -`, { env }, (err, stdout, stderr) => {
             if (err) {
+                console.error("Git commit 命令失败, 错误: ", stderr);
                 reject(err);
             } else {
                 resolve();


### PR DESCRIPTION
目前的提交信息是自动生成的，但是不排除未来可能会使用用户输入的信息。如果有人这么输入提交信息：

`"一些信息\"; rm -rf /*; echo \""`

那么，exec就会执行

`git commit -m ""一些信息\"; rm -rf /*; echo \""`

这样就会触发  `rm -rf /*`

虽然除了让当前工作失败，没有什么影响，但是留着一个漏洞总不是什么好事。

顺便加入了一个小日志。