### PR TITLE
docs: 更新 TTML 规范文档

### DIFF
--- a/instructions/ttml-specification-en.md
+++ b/instructions/ttml-specification-en.md
@@ -6,11 +6,11 @@ This document aims to define a standard TTML (Timed Text Markup Language) file f
 
 This document is based on the W3C TTML1 standard and has been extended for the Apple Music format.
 
-> [!CAUTION]
-> For readability, the following TTML snippets are formatted. However, when uploading a TTML file, formatting is **not allowed**.
+> [!WARNING]
+> For readability, the following TTML snippets are formatted. However, when uploading a TTML file, formatting is **not recommended**. See Section 6 for details.
 
 > [!CAUTION]
-> This specification is currently only valid for the experimental submission process.
+> This specification is currently only effective for the experimental submission process.
 
 ---
 
@@ -48,13 +48,16 @@ Every TTML file must be a valid XML document and include the following basic str
       * `xmlns:itunes` is optional, used for Apple Music-specific attributes like `itunes:timing` and `itunes:song-part`.
       * `xmlns:amll` is used for AMLL metadata.
 
-  * **`xml:lang`**: Optional. Specifies the primary language code of the lyrics on the `<tt>` tag (e.g., `ja` for Japanese, `en` for English).
+  * **`xml:lang`**: Recommended. Specifies the primary language code of the lyrics on the `<tt>` tag (e.g., `ja` for Japanese, `en` for English).
 
-  * **`itunes:timing`**: Optional. Used to declare line-by-line or word-by-word lyrics. If this attribute is not specified, it defaults to word-by-word lyrics. If the TTML file contains no word-by-word syllable information (i.e., all text is directly inside `<p>` tags), it will be automatically identified as line-by-line lyrics.
+  * **`itunes:timing`**: Optional. Used to declare line-by-line or word-by-word lyrics.
+      * `word`: Word-by-word lyrics.
+      * `line`: Line-by-line lyrics.
+      If this attribute is not specified, the robot will automatically determine the timing mode based on the file content: if a lyric line `<p>` contains `<span>` tags with timestamps, it will be treated as **word-by-word lyrics**; otherwise, it will be treated as **line-by-line lyrics**.
 
   * **`body` Element**: Contains all lyric lines (`<p>`) and structural blocks (`<div>`).
 
-      * **`dur`**: **Required**. Defines the total duration of the lyric content. Its value **must be greater than or equal to** the end time of the last timestamp in the file. The timecodes of all inner elements must not exceed this `dur` value.
+      * **`dur`**: **Optional, and does not affect duration calculation. It is mainly for reference.** If included, its value **must be greater than or equal to** the end time of the last timestamp in the file. The timecodes of all inner elements must not exceed this `dur` value.
 
     ```xml
     <body dur="00:04:15.500">
@@ -103,7 +106,7 @@ To link the lyrics to major music platforms, **at least one** platform ID must b
 
 You can use AMLL metadata to credit the lyric author, for example:
 
-  * **Lyric Author Github ID**: `key="ttmlAuthorGithub"`
+  * **Lyric Author GitHub ID**: `key="ttmlAuthorGithub"`
   * **Lyric Author GitHub Username**: `key="ttmlAuthorGithubLogin"`
 
 Please refer to the [AMLL Wiki](https://github.com/Steve-xmh/amll-ttml-tool/wiki/%E6%AD%8C%E8%AF%8D%E5%85%83%E6%95%B0%E6%8D%AE) **(Chinese only)** for more information.
@@ -112,6 +115,7 @@ Please refer to the [AMLL Wiki](https://github.com/Steve-xmh/amll-ttml-tool/wiki
 <head>
     <metadata>
         <!-- Apple Music metadata -->
+        <!-- For example only, you should not add two song title tags. -->
         <ttm:title>Song Title</ttm:title>
         <ttm:agent type="person" xml:id="v1">
             <ttm:name type="full">Artist A</ttm:name>
@@ -171,24 +175,53 @@ When `itunes:timing="Word"`:
 
 In word-by-word mode, spaces between words (syllables) are **significant characters** and must be explicitly represented. The robot recognizes the following methods, with the latter two being the standard.
 
-| Method | Example | Compliance | Description |
-| :--- | :--- | :--- | :--- |
-| **Space inside `<span>`** | `<span begin="00:01.0" end="00:02.0">word </span>` | **Non-compliant, will be auto-corrected** | The robot will automatically extract leading or trailing spaces from the syllable. |
-| **Space outside `<span>`** | ` <span begin="00:01.0" end="00:02.0">word</span>  ` | **Most Compliant** | The space exists as an independent text node between two `<span>` tags. |
-| **Separate space `<span>`** | `<span begin="00:00.000" end="00:00.000"> </span>` | **Allowed** | It is allowed to create a separate `<span>` tag for a space. Recommend to set its begin and end times to `0`. |
+| Method                      | Example                                             | Compliance                                 | Description                                                                                                                                                                          |
+| :-------------------------- | :-------------------------------------------------- | :----------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Space inside `<span>`**   | `<span begin="00:01.0" end="00:02.0">word </span>`  | **Non-compliant(for non-formatted files)** | The robot will automatically extract leading or trailing spaces from the syllable.                                                                                                   |
+| **Space outside `<span>`**  | ` <span begin="00:01.0" end="00:02.0">word</span> ` | **Most Compliant**                         | The space exists as an independent text node between two `<span>` tags.                                                                                                              |
+| **Separate space `<span>`** | `<span begin="00:00.000" end="00:00.000"> </span>`  | **Allowed**                                | It is allowed to create a separate `<span>` tag for a space. It is recommended to set its `begin` and `end` time to the previous syllable's `end` time, or uniformly to `00:00.000`. |
 
-#### 4.2. Line-by-Line Lyrics
+If you submit a formatted TTML file, it is **strongly recommended** to write spaces directly inside the `span` tag to avoid strange issues. See Section 6 for details.
+
+#### 4.2. Auto-segmentation
+
+When timing Japanese and Korean songs, you might place multiple characters into a single timed syllable (e.g., contracted sounds). Auto-segmentation can help you evenly divide these syllables containing multiple characters, splitting the long `<span>` into multiple independent `<span>` tags, each containing a single character, and distributing the time proportionally by the number of characters.
+
+Auto-segmentation is also applicable to lyrics obtained directly from Apple Music (which often merges multiple CJK characters with similar durations into a single syllable). You just need to add the necessary metadata and enable the auto-segmentation feature.
+
+It is generally recommended that each `<span>` contains only **one** CJK character. Multiple CJK characters may cause an unnatural glow effect.
+
+**Input Example:**
+```xml
+<span begin="10.0s" end="12.0s">你好世界</span>
+```
+
+**Output with Auto-segmentation Enabled:**
+```xml
+<span begin="10.000" end="10.500">你</span>
+<span begin="10.500" end="11.000">好</span>
+<span begin="11.000" end="11.500">世</span>
+<span begin="11.500" end="12.000">界</span>
+```
+
+The auto-segmentation feature will also attempt to split an English word by its syllables, e.g., `analyse` -> `an-a-lyse`. **If this is not your desired behavior, do not enable the auto-segmentation feature.**
+
+**Punctuation Weight** is used to control how much duration should be allocated to punctuation marks when splitting. Generally, you do not need to modify it unless you specifically want them to last shorter or longer.
+
+#### 4.3. Line-by-Line Lyrics
 
 When `itunes:timing="Line"`, the robot only parses the timestamp of the entire line and ignores the timestamp information of any inner `<span>` elements (which, in practice, should not exist).
 
-  * Each line of lyrics is in a **`<p>` tag with `begin` and `end` attributes**.
-  * All text content for the line is placed directly within the `<p>` tag. You can use `<span>` to add translations and other information, but the `begin` / `end` attributes of these `<span>` will be ignored.
+*   Each line of lyrics is in a **`<p>` tag with `begin` and `end` attributes**.
+*   All text content for the line is placed directly within the `<p>` tag. You can use `<span>` to add translations and other information, but the `begin` / `end` attributes of these `<span>` will be ignored.
 
 ```xml
 <p begin="00:01.000" end="00:03.500">A line of lyrics</p>
 ```
 
-#### 4.3 Timestamp Format
+If you are uploading line-by-line lyrics, it is recommended to enable the "**This is line-by-line lyrics**" option. Although it can be recognized without it, enabling it ensures it won't be misjudged as word-by-word lyrics.
+
+#### 4.4 Timestamp Format
 
 All time values in this document (e.g., the values of `begin`, `end`, `dur` attributes) **must** follow one of the formats below.
 
@@ -229,18 +262,18 @@ You can directly provide a time value in seconds with an `s` suffix. This can be
 
 ##### **Summary of Valid Formats**
 
-| Category | Format | Example | Parsed Milliseconds |
-| :--- | :--- | :--- | :--- |
-| **Full Format** | `HH:MM:SS.fff` | `00:02:35.500` | `155500` |
-| | `HH:MM:SS.f` | `00:02:35.5` | `155500` |
-| | `HH:MM:SS` | `00:02:35` | `155000` |
-| **Omit Hours** | `MM:SS.ff` | `02:35.55` | `155550` |
-| | `MM:SS` | `02:35` | `155000` |
-| **Seconds Only** | `SS.fff` | `35.123` | `35123` |
-| | `SS` | `35` | `35000` |
-| | `SS` (over 60) | `95` | `95000` |
-| **`s` Suffix Format** | `f.f...s` | `15.8s` | `15800` |
-| | `fs` | `15s` | `15000` |
+| Category              | Format         | Example        | Parsed Milliseconds |
+| :-------------------- | :------------- | :------------- | :------------------ |
+| **Full Format**       | `HH:MM:SS.fff` | `00:02:35.500` | `155500`            |
+|                       | `HH:MM:SS.f`   | `00:02:35.5`   | `155500`            |
+|                       | `HH:MM:SS`     | `00:02:35`     | `155000`            |
+| **Omit Hours**        | `MM:SS.ff`     | `02:35.55`     | `155550`            |
+|                       | `MM:SS`        | `02:35`        | `155000`            |
+| **Seconds Only**      | `SS.fff`       | `35.123`       | `35123`             |
+|                       | `SS`           | `35`           | `35000`             |
+|                       | `SS` (over 60) | `95`           | `95000`             |
+| **`s` Suffix Format** | `f.f...s`      | `15.8s`        | `15800`             |
+|                       | `fs`           | `15s`          | `15000`             |
 
 -----
 
@@ -297,7 +330,7 @@ You can nest `<span>` tags within the main lyric line to provide translations, r
 
   * **Translation**: Use `<span ttm:role="x-translation" xml:lang="language-code">...</span>`.
   * **Romanization**: Use `<span ttm:role="x-roman" xml:lang="language-Latn" xml:scheme="romanization-scheme">...</span>`.
-  * **Background Vocals**: Use `<span ttm:role="x-bg" begin="..." end="...">...</span>`. The tag for background vocals must always be placed at the very end of the main lyrics. It is recommended to wrap the background vocal text in half-width parentheses. The robot will also automatically add parentheses (if they are missing). **Do not add double parentheses**.
+  *   **Background Vocals**: Use `<span ttm:role="x-bg" begin="..." end="...">...</span>`. If the background vocal appears before the main vocal, it is recommended to place the `<span ttm:role="x-bg">` tag before the main vocal's `<span>` tag. Otherwise, place the `<span ttm:role="x-bg">` tag at the end of the `<p>` tag. It is recommended to wrap the background vocal text in half-width parentheses. The robot will also automatically add parentheses (if they are missing). It is not recommended to add two or more parentheses, as although the library's robot can handle it, other parsers may not.
 
 ```xml
 <p begin="00:25.100" end="00:32.500" itunes:key="L1" ttm:agent="v1">
@@ -334,25 +367,56 @@ You can nest `<span>` tags within the main lyric line to provide translations, r
 
 #### 5.4 Apple Music Style Translation
 
-In addition to the inline translation method (`ttm:role="x-translation"`) described in `5.3`, the robot is also compatible with Apple Music style translations.
+In addition to the inline auxiliary lyrics (e.g., `<span ttm:role="x-translation">...</span>`) described in `5.3`, the robot is also compatible with Apple Music style translations and transliterations defined in the `<head>`.
 
 > [!CAUTION]
-> When both formats are present, the robot will use the Apple Music style translation content and ignore the inline translation content.
+> When both formats are present, the robot will get the Apple Music style translation from the `<head>` and append it to the translation list of that line. **This may lead to double translation**.
+> To avoid duplication, ensure that a translation for the same language appears in only one format. For example, if a translation with `xml:lang="zh-CN"` is defined in the `<head>`, the corresponding line in the `<body>` should not also contain a translation `<span>` with `xml:lang="zh-CN"`.
 
 ##### **Structure Explanation**
 
-1.  **Location**: All translation data must be placed inside `<head><metadata>...</metadata></head>`.
-2.  **Main Container**: A `<iTunesMetadata>` tag is required as a container, with its namespace declared: `xmlns="http://music.apple.com/lyric-ttml-internal"`.
-3.  **Translation Block**:
-      * Inside `<iTunesMetadata>`, use the `<translations>` tag to wrap one or more `<translation>` blocks.
-      * Each `<translation>` represents a translation in one language and **must** include the following attributes:
-          * `type="translation-type"`, which can be `subtitle` or `replacement`. `subtitle` is suitable for most translation content, while `replacement` is generally used for conversions between Simplified and Traditional Chinese.
-          * `xml:lang="language-code"` (e.g., `zh-Hans-CN`)
-4.  **Text Linking**:
-      * Inside a `<translation>`, each translated line is carried by a separate `<text>` tag.
-      * The `for` attribute links the translated text to a lyric line, and its value **must** exactly match the `itunes:key` value of the corresponding `<p>` tag in the `<body>`.
+1.  **Location**: All Apple Music style auxiliary track data must be placed inside `<head><metadata>...</metadata></head>`.
+2.  **Main Container**: A `<iTunesMetadata>` tag is required as a container for all Apple Music specific metadata.
+3.  **Track Type Container**:
+    *   **Translation**: Use the `<translations>` tag to wrap.
+    *   **Transliteration**: Use the `<transliterations>` tag to wrap.
+4.  **Language Block**:
+    *   Inside `<translations>` or `<transliterations>`, each `<translation>` or `<transliteration>` block represents a track for one language.
+    *   Each `<translation>` represents a translation in one language and **must** include the following attributes:
+        *   `type="translation-type"`, which can be `subtitle` or `replacement`. `subtitle` is suitable for most translation content, while `replacement` is generally used for conversions between Simplified and Traditional Chinese.
+        *   `xml:lang="language-code"` (e.g., `zh-Hans-CN`)
+5.  **Text Linking**:
+    *   Inside each language block, the content is carried by one or more `<text>` tags.
+    *   The `for` attribute links the content to a lyric line, and its value **must** exactly match the `itunes:key` value of the corresponding `<p>` tag in the `<body>` (e.g., `for="L1"`).
 
-##### **Example**
+##### **Content Format**
+
+The content inside a `<text>` tag can be in one of two formats:
+
+*   **Line-by-line**: Contains plain text for the translation or transliteration directly.
+    ```xml
+    <text for="L1">This is a line-by-line translation</text>
+    ```
+
+*   **Word-by-word**: Contains one or more `<span>` tags with `begin` and `end` attributes.
+    ```xml
+    <text for="L2">
+      <span begin="10.0s" end="10.5s">A </span>
+      <span begin="10.5s" end="11.0s">syllable-timed </span>
+      <span begin="11.0s" end="11.8s">translation</span>
+    </text>
+    ```
+
+##### **Background Vocals**
+
+You can use `<span ttm:role="x-bg">` within a `<text>` tag to provide translations or transliterations for background vocals.
+
+*   For **line-by-line** background vocal auxiliary lyrics, use a `<span>` with `ttm:role="x-bg"` inside the `<text>` tag.
+*   For **word-by-word** background vocal auxiliary lyrics, nest timed `<span>` tags inside the `<span>` with `ttm:role="x-bg"`.
+
+-----
+
+##### **Example 1: Line-by-line Translation**
 
 The following example shows how to define a Simplified Chinese translation in the header and link it to the lyric lines in the body.
 
@@ -381,25 +445,25 @@ The following example shows how to define a Simplified Chinese translation in th
     ...
     <div itunes:songPart="Chorus">
         <p begin="45.404" end="48.709" itunes:key="L23" ttm:agent="v1">
-            <span begin="45.404" end="45.755">Gold</span>
-            <span begin="45.755" end="46.696">jewelry</span>
-            <span begin="46.696" end="47.627">shining</span>
-            <span begin="47.627" end="47.979">so</span>
+            <span begin="45.404" end="45.755">Gold </span>
+            <span begin="45.755" end="46.696">jewelry </span>
+            <span begin="46.696" end="47.627">shining </span>
+            <span begin="47.627" end="47.979">so </span>
             <span begin="47.979" end="48.709">bright</span>
         </p>
         <p begin="48.739" end="52.311" itunes:key="L24" ttm:agent="v1">
-            <span begin="48.739" end="50.290">Strawberry</span>
-            <span begin="50.290" end="51.226">champagne</span>
-            <span begin="51.226" end="51.584">on</span>
+            <span begin="48.739" end="50.290">Strawberry </span>
+            <span begin="50.290" end="51.226">champagne </span>
+            <span begin="51.226" end="51.584">on </span>
             <span begin="51.584" end="52.311">ice</span>
         </p>
         <p begin="52.320" end="54.350" itunes:key="L25" ttm:agent="v1">
-            <span begin="52.320" end="52.826">Lucky</span>
-            <span begin="52.826" end="53.090">for</span>
-            <span begin="53.090" end="53.300">you,</span>
-            <span begin="53.300" end="53.484">that's</span>
-            <span begin="53.484" end="53.732">what</span>
-            <span begin="53.732" end="53.918">I</span>
+            <span begin="52.320" end="52.826">Lucky </span>
+            <span begin="52.826" end="53.090">for </span>
+            <span begin="53.090" end="53.300">you, </span>
+            <span begin="53.300" end="53.484">that's </span>
+            <span begin="53.484" end="53.732">what </span>
+            <span begin="53.732" end="53.918">I </span>
             <span begin="53.918" end="54.350">like</span>
         </p>
     </div>
@@ -409,10 +473,80 @@ The following example shows how to define a Simplified Chinese translation in th
 
 -----
 
+##### **Example 2: Word-by-word Translation and Transliteration**
+
+**Lyric line in the `<body>` section:**
+```xml
+<body>
+  <p begin="10.0s" end="12.0s" itunes:key="L1">
+      <span begin="10.0s" end="10.8s">두렵지는 않아</span>
+      <span ttm:role="x-bg">
+          <span begin="11.0s" end="11.8s">(흥미로울 뿐)</span>
+      </span>
+  </p>
+</body>
+```
+
+**Corresponding auxiliary tracks defined in the `<head>` section:**
+```xml
+<head>
+  <metadata>
+    <iTunesMetadata>
+      <translations>
+        <translation xml:lang="en-US">
+          <text for="L1">
+            I'm not afraid
+            <span ttm:role="x-bg">(Just interesting)</span>
+          </text>
+        </translation>
+      </translations>
+      <transliterations>
+        <transliteration xml:lang="ko-Latn">
+          <text for="L1">
+            <span begin="10.0s" end="10.8s">duryeopjineun ana</span>
+            <span ttm:role="x-bg">
+              <span begin="11.0s" end="11.4s">heungmiroul </span>
+              <span begin="11.4s" end="11.8s">ppun</span>
+            </span>
+          </text>
+        </transliteration>
+      </transliterations>
+    </iTunesMetadata>
+  </metadata>
+</head>
+```
+
+---
+
 ### 6. Whitespace and Formatting Rules
 
-  * **Whitespace Handling**: We automatically normalize whitespace in the lyric text. Multiple consecutive spaces (including newlines, tabs, etc.) will be merged into a single standard half-width space, and leading/trailing spaces will be removed. **In word-by-word mode, the space between words is crucial, please be sure to follow the rules in 4.1.1.**
-  * **Formatting Prohibited**: It is **absolutely forbidden** to use any XML/HTML formatting tools (like Prettier or built-in IDE formatters) to format the TTML file. **Formatting will add or change the independent space text nodes between `<span>` tags, causing the loss of space information.** The file should maintain a compressed structure, meaning all characters are on a single line.
+#### 6.1 Formatting Support
+
+You can use formatting tools to format your TTML file. However, any space after a `<span>` tag will be lost (if the `<span>` tag is followed by a newline).
+
+To preserve these spaces, please write the space directly inside the `<span>` tag. For example:
+```xml
+<p begin="45.404" end="48.709" itunes:key="L23" ttm:agent="v1">
+    <span begin="45.404" end="45.755">Gold </span>
+    <span begin="45.755" end="46.696">jewelry </span>
+    <span begin="46.696" end="47.627">shining </span>
+    <span begin="47.627" end="47.979">so </span>
+    <span begin="47.979" end="48.709">bright </span>
+</p>
+```
+
+Alternatively, write two syllables that should be separated by a space on the same line:
+```xml
+<span begin="10s" end="11s">word1</span> <span begin="12s" end="13s">word2</span>
+```
+
+When using the experimental submission process to generate a formatted TTML file, it will, by default, write spaces directly into the `<span>` tags.
+
+#### 6.2 Whitespace Handling
+
+We automatically normalize whitespace in the lyric text, merging multiple consecutive spaces (including newlines, tabs, etc.) into a single standard half-width space and removing spaces inside `<span>` tags.
+
+In **word-by-word mode**, the space between words is crucial. Although formatting is allowed, we still **strongly recommend** following the best practices defined in **4.1.1. Whitespace Handling Rules** to represent spaces between words.
 
 -----
 


### PR DESCRIPTION
主要变更：

1.  允许格式化：格式化的规则从“不允许”调整为“不建议”。
2.  自动分词说明：增加了自动分词功能的说明。
3.  扩展 Apple Music 样式支持：
    *   增加了逐字音译和翻译的支持。
    *   冲突处理逻辑：当两种翻译格式（内嵌和 Apple Music 样式）同时存在时，现在会追加而非替换。
    *   新增了对背景人声 (`x-bg`) 的支持说明和更完整的示例。
4.  属性与规则调整：
    *   `<body>` 标签的 `dur` 属性现在是可选的了。
    *   背景人声的标签现在可以放在歌词行之前了（和 Apple Music 的规范对齐）。