### PR TITLE
refactor(close-stale-prs): 只通过待更新标签来关闭 PR

### DIFF
--- a/scripts/close-stale-prs/index.ts
+++ b/scripts/close-stale-prs/index.ts
@@ -4,14 +4,21 @@ const LABEL_NAME = "待更新";
 const DAYS_THRESHOLD = 7;
 
 const repoEnv = process.env.GITHUB_REPOSITORY || "";
-const OWNER = process.env.OWNER || repoEnv.split("/")[0] || "amll-dev";
-const REPO = process.env.REPO || repoEnv.split("/")[1] || "amll-ttml-db";
+const OWNER = process.env.OWNER || repoEnv.split("/")[0];
+const REPO = process.env.REPO || repoEnv.split("/")[1];
 const TOKEN = process.env.GITHUB_TOKEN;
 
 const IS_DRY_RUN = process.env.DRY_RUN === "true";
 
 if (!TOKEN) {
 	console.error("缺少环境变量 GITHUB_TOKEN");
+	process.exit(1);
+}
+
+if (!OWNER || !REPO) {
+	console.error(
+		"缺少仓库信息：请通过 OWNER/REPO 或 GITHUB_REPOSITORY 环境变量指定目标仓库",
+	);
 	process.exit(1);
 }
 


### PR DESCRIPTION
此 PR 优化了自动关闭闲置 PR 的判断逻辑

* **背景**：目前主要的审核工具 Test Tool 已支持在打回 PR 时自动添加“待更新”标签，并在用户更新 PR 时由机器人自动移除
* **改动**：简化了自动关闭未更新 PR 的自动化脚本。将其从原先 *综合判断 Changes Requested 状态与提交时间* 的复杂机制，更改为仅依赖“待更新”标签来触发关闭操作
* **收益**：自动化关闭机制更加稳定可靠，修复了 #8521 被错误关闭的 bug