### PR TITLE
chore: 在重建歌词文件夹的提交信息中移除时间戳

### DIFF
--- a/scripts/rebuild-folder/src/main.rs
+++ b/scripts/rebuild-folder/src/main.rs
@@ -776,8 +776,7 @@ fn main() -> Result<()> {
         } else {
             println!("工作树已变更，正在提交更改");
             add_file_to_git("../..")?;
-            let time = Utc::now();
-            commit(&format!("于 {time:?} 重新构建更新"))?;
+            commit("重新构建歌词文件夹")?;
             push("main")?;
 
             println!("文件夹重建完毕！耗时: {:?}", t.elapsed());


### PR DESCRIPTION
Git 的提交信息已经有了提交时间了，不需要再在提交信息里面写时间戳了