### PR TITLE
doc: 删去开发者招募

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,6 @@
 
 ***
 
-> [!TIP]
->
-> ## 📣【公告】
-> 我们正在招募长期维护开发者！  
-> 更多信息请到 [公告帖](https://github.com/amll-dev/amll-ttml-db/discussions/8127) 查看  
-> 感谢各位投稿者对本项目的支持！
-
-***
-
 > [!Warning]
 > 致使用歌词库的开发者：  
 > 本仓库已迁移至 [amll-dev](https://github.com/amll-dev) 组织，仓库链接已更新为 https://github.com/amll-dev/amll-ttml-db ，请下游仓库注意更新。


### PR DESCRIPTION
- 因为词库的README太冗杂了，~~在这里招开发者效率也不高，转去本体应该会好一些。~~
- 已在本体同步提出 增加招募信息的 PR amll-dev/applemusic-like-lyrics/pull/544
- 开头的东西太多很容易让人没欲望看完